### PR TITLE
Support Docker & docker-compose

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker-compose build bot
+      run: docker-compose up --build bot

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker-compose build bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:latest
+
+#Create working directory
+RUN mkdir -p /usr/src/bot
+
+#Change to working directory
+WORKDIR /usr/src/bot
+
+#Copy package.json to working directory, install dependencies using NPM
+COPY package.json /usr/src/bot
+RUN npm install
+
+#Copy bot files over
+COPY . /usr/src/bot
+
+#Entry command
+CMD ["node", "index.js"]

--- a/commands/role-claim/setup-side-projects-roles.js
+++ b/commands/role-claim/setup-side-projects-roles.js
@@ -82,7 +82,7 @@ module.exports = {
     description: "Setting up community roles reaction message",
     // find the targeted bal user
     async execute (client, message, args, Discord, profileData, prefix) {
-        if (message.author.id != config.ownerToken) {
+        if (message.author.id != message.guild.ownerId) {
             message.reply('You do not have permission to use this command!')
             return
         }

--- a/config.js
+++ b/config.js
@@ -12,3 +12,5 @@ module.exports = {
     "token" : process.env.BOT_TOKEN, 
     "mongoPath" : process.env.MONGO_URL,
 };
+
+poiauwhgopiuAHWGOP{IGHAW9o0

--- a/config.js
+++ b/config.js
@@ -9,7 +9,6 @@ require('module-alias/register')
 require('dotenv').config();
 
 module.exports = { 
-    "token" : process.env.BOTTOKEN,
-    "ownerToken" : process.env.OWNERTOKEN,    
-    "mongoPath" : process.env.MONGOPATH,
+    "token" : process.env.BOT_TOKEN, 
+    "mongoPath" : process.env.MONGO_URL,
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  mongo:
+    container_name: mongo
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+    ports:
+      - 27017 #Expose port ONLY to internal services, NOT public
+    volumes: #Comment out if on development server and you don't care about persistant data
+      - mongo_data:/data/db #See above
+  bot:
+    container_name: bot
+    build: .
+    environment:
+      - MONGO_URL=mongodb://root:password@mongo
+      - BOT_TOKEN={DISCORD_BOT_TOKEN}
+    depends_on:
+      - mongo
+    links:
+      - mongo:mongo
+      
+volumes:
+  mongo_data:

--- a/handlers/command-handler.js
+++ b/handlers/command-handler.js
@@ -46,5 +46,5 @@ module.exports = ( client, Discord ) => {
         }
     }
 
-    ['economics', 'mini-games', 'school', 'role-claim'].forEach(e => load_dir(e));
+    ['economics', 'school', 'role-claim'].forEach(e => load_dir(e));
 }


### PR DESCRIPTION
Wanted to start helping out a bit more with the bot, but prefer to do my development in a docker container.

For those unaware, Docker is a great DevOps tool to help run programs and codebases across any platform, so long as they have Docker installed. See more about docker here: https://www.docker.com

What's new:
- Dockerfile [Allows for Docker RUN, useful for if you already have a seperate mongodb instance]
- docker-compose.yml [Allows for a complete setup (mongodb included)]

What's changed:
- Removed the OWNERTOKEN environmental variable, we can fetch the guild owner through a message object.
- Converted the environmental variables naming conventions to fit within standards

How to use:
Assuming you already have docker and docker-compose installed, the following commands are used most often:

**Listing all Docker containers/services in compose:**
`docker-compose ps`

**Building the MongoDB Database:**
`docker-compose up --build -d mongo`

**Accessing MongoDB Logs (attached):**
`docker-compose logs -f mongo`

**Attaching to MongoDB:**
`docker-compose exec -it mongo mongosh`

**Building Bot Container:**
`docker-compose up --build -d bot`

**Accessing Bot Logs:**
`docker-compose logs -f bot`

**Attaching to Bot Container:**
`docker-compose exec -it bot sh`


Additionally, since the bot is dependant on the database, you can init everything by doing:
`docker-compose up --build` 